### PR TITLE
fixed typo + suggestion

### DIFF
--- a/com.koushikdutta.backup/values-fr/strings.xml
+++ b/com.koushikdutta.backup/values-fr/strings.xml
@@ -156,7 +156,7 @@
     <string name="whats_new">Nouveautés</string>
     <string name="version">Version</string>
     <string name="user_dictionary">Dictionnaire Utilisateur</string>
-    <string name="user_dictionary_summary">Mots et texte prédictif définis par l\'Utiliateur</string>
+    <string name="user_dictionary_summary">Mots et texte prédictif définis par l\'Utilisateur</string>
     <string name="messaging_storage_summary">Journaux d\'Appels et SMS</string>
     <string name="password_or_pin">Code ou Mot de Passe</string>
     <string name="device_encryption_password">Mot de Passe de chiffrement du périphérique</string>


### PR DESCRIPTION
Hi, 

I updated to Carbon 1.0.4.6 and I noticed that the "what's news" content is only written in English, and not available in strings.xml to get translation.

Is there any way to localize that too ?
People would understand better the new functionality / bug fixes.

![whats new](https://f.cloud.github.com/assets/3460127/241122/cdc28be0-898b-11e2-8e85-86fc3a26f4d7.png)
